### PR TITLE
Fix ServerSelectionTimeoutError: No servers found yet

### DIFF
--- a/Alerta_Single_Instance.json
+++ b/Alerta_Single_Instance.json
@@ -171,6 +171,7 @@
                                     "  ServerName localhost\n",
                                     "  WSGIDaemonProcess alerta processes=5 threads=5\n",
                                     "  WSGIProcessGroup alerta\n",
+                                    "  WSGIApplicationGroup %{GLOBAL}\n",
                                     "  WSGIScriptAlias / /var/www/api.wsgi\n",
                                     "  WSGIPassAuthorization On\n",
                                     "  ErrorLog ${APACHE_LOG_DIR}/error.log\n",


### PR DESCRIPTION
Apache WSGI should use context of the first interpreter created by Python when it is initialised to avoid the MongoDB issue caused by creating database connections and then forking.

See https://jira.mongodb.org/browse/PYTHON-961
